### PR TITLE
Filter api response [IAM-165]

### DIFF
--- a/castle.go
+++ b/castle.go
@@ -171,27 +171,27 @@ type castleAPIResponse struct {
 
 // Filter sends a filter request to castle.io
 // see https://reference.castle.io/#operation/filter for details
-func (c *Castle) Filter(context *Context, event Event, user User, properties map[string]string) error {
+func (c *Castle) Filter(ctx context.Context, castleCtx *Context, event Event, user User, properties map[string]string) error {
 	e := &castleAPIRequest{
 		Type:         event.EventType,
 		Status:       event.EventStatus,
-		RequestToken: context.RequestToken,
+		RequestToken: castleCtx.RequestToken,
 		User:         user,
-		Context:      context,
+		Context:      castleCtx,
 		Properties:   properties,
 	}
-	return c.SendFilterCall(e)
+	return c.SendFilterCall(ctx, e)
 }
 
 // SendFilterCall is a plumbing method constructing the HTTP req/res and interpreting results
-func (c *Castle) SendFilterCall(e *castleAPIRequest) error {
+func (c *Castle) SendFilterCall(ctx context.Context, e *castleAPIRequest) error {
 	b := new(bytes.Buffer)
 	err := json.NewEncoder(b).Encode(e)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, FilterEndpoint, b)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, FilterEndpoint, b)
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,8 @@ func authenticationRecommendedActionFromString(action string) AuthenticationReco
 // Risk sends a risk request to castle.io
 // see https://reference.castle.io/#operation/risk for details
 func (c *Castle) Risk(
-	context *Context,
+	ctx context.Context,
+	castleCtx *Context,
 	event Event,
 	user User,
 	properties map[string]string,
@@ -254,23 +255,23 @@ func (c *Castle) Risk(
 	e := &castleAPIRequest{
 		Type:         event.EventType,
 		Status:       event.EventStatus,
-		RequestToken: context.RequestToken,
+		RequestToken: castleCtx.RequestToken,
 		User:         user,
-		Context:      context,
+		Context:      castleCtx,
 		Properties:   properties,
 	}
-	return c.SendRiskCall(e)
+	return c.SendRiskCall(ctx, e)
 }
 
 // SendRiskCall is a plumbing method constructing the HTTP req/res and interpreting results
-func (c *Castle) SendRiskCall(e *castleAPIRequest) (AuthenticationRecommendedAction, error) {
+func (c *Castle) SendRiskCall(ctx context.Context, e *castleAPIRequest) (AuthenticationRecommendedAction, error) {
 	b := new(bytes.Buffer)
 	err := json.NewEncoder(b).Encode(e)
 	if err != nil {
 		return RecommendedActionNone, err
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, RiskEndpoint, b)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, RiskEndpoint, b)
 	if err != nil {
 		return RecommendedActionNone, err
 	}

--- a/castle.go
+++ b/castle.go
@@ -45,15 +45,15 @@ const (
 	EventStatusRequested EventStatus = "$requested"
 )
 
-// AuthenticationRecommendedAction encapsulates the 3 possible responses from auth call (allow, challenge, deny)
-type AuthenticationRecommendedAction string
+// RecommendedAction encapsulates the 3 possible responses from auth call (allow, challenge, deny)
+type RecommendedAction string
 
 // See https://castle.io/docs/authentication
 const (
-	RecommendedActionNone      AuthenticationRecommendedAction = ""
-	RecommendedActionAllow     AuthenticationRecommendedAction = "allow"
-	RecommendedActionChallenge AuthenticationRecommendedAction = "challenge"
-	RecommendedActionDeny      AuthenticationRecommendedAction = "deny"
+	RecommendedActionNone      RecommendedAction = ""
+	RecommendedActionAllow     RecommendedAction = "allow"
+	RecommendedActionChallenge RecommendedAction = "challenge"
+	RecommendedActionDeny      RecommendedAction = "deny"
 )
 
 // New creates a new castle client
@@ -230,7 +230,7 @@ func (c *Castle) SendFilterCall(ctx context.Context, e *castleAPIRequest) error 
 	return err
 }
 
-func authenticationRecommendedActionFromString(action string) AuthenticationRecommendedAction {
+func recommendedActionFromString(action string) RecommendedAction {
 	switch action {
 	case "allow":
 		return RecommendedActionAllow
@@ -251,7 +251,7 @@ func (c *Castle) Risk(
 	event Event,
 	user User,
 	properties map[string]string,
-) (AuthenticationRecommendedAction, error) {
+) (RecommendedAction, error) {
 	e := &castleAPIRequest{
 		Type:         event.EventType,
 		Status:       event.EventStatus,
@@ -264,7 +264,7 @@ func (c *Castle) Risk(
 }
 
 // SendRiskCall is a plumbing method constructing the HTTP req/res and interpreting results
-func (c *Castle) SendRiskCall(ctx context.Context, e *castleAPIRequest) (AuthenticationRecommendedAction, error) {
+func (c *Castle) SendRiskCall(ctx context.Context, e *castleAPIRequest) (RecommendedAction, error) {
 	b := new(bytes.Buffer)
 	err := json.NewEncoder(b).Encode(e)
 	if err != nil {
@@ -307,7 +307,7 @@ func (c *Castle) SendRiskCall(ctx context.Context, e *castleAPIRequest) (Authent
 		return RecommendedActionNone, errors.Errorf("%s: %s", resp.Type, resp.Message)
 	}
 
-	return authenticationRecommendedActionFromString(resp.Policy.Action), err
+	return recommendedActionFromString(resp.Policy.Action), err
 }
 
 // WebhookBody encapsulates body of webhook notificationc coming from castle.io

--- a/castle_test.go
+++ b/castle_test.go
@@ -43,7 +43,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 		EventStatus: castle.EventStatusSucceeded,
 	}
 
-	err = cstl.Filter(
+	res, err := cstl.Filter(
 		ctx,
 		castle.ContextFromRequest(req),
 		evt,
@@ -55,6 +55,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 	)
 
 	assert.Error(t, err)
+	assert.Equal(t, castle.RecommendedActionNone, res)
 
 	fs = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
@@ -68,7 +69,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 		EventStatus: castle.EventStatusSucceeded,
 	}
 
-	err = cstl.Filter(
+	res, err = cstl.Filter(
 		ctx,
 		castle.ContextFromRequest(req),
 		evt,
@@ -80,11 +81,12 @@ func TestCastle_SendFilterCall(t *testing.T) {
 	)
 
 	assert.Error(t, err)
+	assert.Equal(t, castle.RecommendedActionNone, res)
 
 	fs = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		w.WriteHeader(201)
-		_, err := w.Write([]byte(`{"policy": {"name": "name"}}`))
+		_, err := w.Write([]byte(`{"policy": {"action": "allow"}}`))
 		require.NoError(t, err)
 	}))
 
@@ -95,7 +97,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 		EventStatus: castle.EventStatusSucceeded,
 	}
 
-	err = cstl.Filter(
+	res, err = cstl.Filter(
 		ctx,
 		castle.ContextFromRequest(req),
 		evt,
@@ -107,6 +109,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 	)
 
 	assert.NoError(t, err)
+	assert.Equal(t, castle.RecommendedActionAllow, res)
 }
 
 func TestCastle_Filter(t *testing.T) {
@@ -156,7 +159,7 @@ func TestCastle_Filter(t *testing.T) {
 
 	castle.FilterEndpoint = ts.URL
 
-	err = cstl.Filter(
+	res, err := cstl.Filter(
 		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
@@ -170,6 +173,7 @@ func TestCastle_Filter(t *testing.T) {
 		map[string]string{"prop1": "propValue1"},
 	)
 	require.NoError(t, err)
+	assert.Equal(t, castle.RecommendedActionNone, res)
 
 	assert.True(t, executed)
 }

--- a/castle_test.go
+++ b/castle_test.go
@@ -1,6 +1,7 @@
 package castle_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -23,6 +24,7 @@ func configureRequest() *http.Request {
 }
 
 func TestCastle_SendFilterCall(t *testing.T) {
+	ctx := context.Background()
 	req := configureRequest()
 
 	cstl, err := castle.New("secret-string")
@@ -42,6 +44,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 	}
 
 	err = cstl.Filter(
+		ctx,
 		castle.ContextFromRequest(req),
 		evt,
 		castle.User{
@@ -66,6 +69,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 	}
 
 	err = cstl.Filter(
+		ctx,
 		castle.ContextFromRequest(req),
 		evt,
 		castle.User{
@@ -92,6 +96,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 	}
 
 	err = cstl.Filter(
+		ctx,
 		castle.ContextFromRequest(req),
 		evt,
 		castle.User{
@@ -105,6 +110,7 @@ func TestCastle_SendFilterCall(t *testing.T) {
 }
 
 func TestCastle_Filter(t *testing.T) {
+	ctx := context.Background()
 	req := configureRequest()
 
 	cstl, err := castle.New("secret-string")
@@ -151,6 +157,7 @@ func TestCastle_Filter(t *testing.T) {
 	castle.FilterEndpoint = ts.URL
 
 	err = cstl.Filter(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -201,6 +208,7 @@ func TestContextFromRequest(t *testing.T) {
 }
 
 func TestCastle_Risk(t *testing.T) {
+	ctx := context.Background()
 	req := configureRequest()
 
 	cstl, err := castle.New("secret-string")
@@ -247,6 +255,7 @@ func TestCastle_Risk(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	_, err = cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -264,6 +273,7 @@ func TestCastle_Risk(t *testing.T) {
 }
 
 func TestCastle_SendRiskCall(t *testing.T) {
+	ctx := context.Background()
 	req := configureRequest()
 
 	cstl, err := castle.New("secret-string")
@@ -278,6 +288,7 @@ func TestCastle_SendRiskCall(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	res, err := cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -301,6 +312,7 @@ func TestCastle_SendRiskCall(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	res, err = cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -325,6 +337,7 @@ func TestCastle_SendRiskCall(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	res, err = cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -350,6 +363,7 @@ func TestCastle_SendRiskCall(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	res, err = cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -375,6 +389,7 @@ func TestCastle_SendRiskCall(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	res, err = cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,
@@ -400,6 +415,7 @@ func TestCastle_SendRiskCall(t *testing.T) {
 	castle.RiskEndpoint = ts.URL
 
 	res, err = cstl.Risk(
+		ctx,
 		castle.ContextFromRequest(req),
 		castle.Event{
 			EventType:   castle.EventTypeLogin,


### PR DESCRIPTION
`Filter` endpoint is recommended to be called in the [request password reset](https://docs.castle.io/docs/profile-reset-activity) step.


Breaking change, but `cust-auth-provider` is the only client.