### PR TITLE
update castle sdk remove deprecated fields

### DIFF
--- a/client.go
+++ b/client.go
@@ -103,7 +103,7 @@ func (c *Castle) Risk(ctx context.Context, req *Request) (RecommendedAction, err
 		return RecommendedActionNone, errors.New("request.Context cannot be nil")
 	}
 	createdAt := req.CreatedAt
-	if req.CreatedAt.IsZero() {
+	if createdAt.IsZero() {
 		createdAt = time.Now()
 	}
 	r := &castleRiskAPIRequest{

--- a/client.go
+++ b/client.go
@@ -77,7 +77,7 @@ func (c *Castle) Filter(ctx context.Context, req *Request) (RecommendedAction, e
 		Username: req.User.Name,
 	}
 	createdAt := req.CreatedAt
-	if req.CreatedAt.IsZero() {
+	if createdAt.IsZero() {
 		createdAt = time.Now()
 	}
 	r := &castleFilterAPIRequest{

--- a/client.go
+++ b/client.go
@@ -74,7 +74,7 @@ func (c *Castle) Filter(ctx context.Context, req *Request) (RecommendedAction, e
 	}
 	params := Params{
 		Email:    req.User.Email,
-		Username: req.User.Name,
+		Username: req.User.ID,
 	}
 	createdAt := req.CreatedAt
 	if createdAt.IsZero() {

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -166,7 +166,6 @@ func TestCastle_Filter(t *testing.T) {
 			assert.True(t, ok)
 
 			err = json.NewDecoder(r.Body).Decode(reqData)
-			spew.Dump(reqData)
 			require.NoError(t, err)
 
 			assert.Equal(t, castle.EventTypeLogin, reqData.Type)

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,6 +33,7 @@ func configureRequest(httpReq *http.Request) *castle.Request {
 		},
 		User: castle.User{
 			ID:     "user-id",
+			Email:  "user@test.com",
 			Traits: map[string]string{"trait1": "traitValue1"},
 		},
 		Properties: map[string]string{"prop1": "propValue1"},
@@ -150,7 +152,7 @@ func TestCastle_Filter(t *testing.T) {
 				Type         castle.EventType   `json:"type"`
 				Status       castle.EventStatus `json:"status"`
 				RequestToken string             `json:"request_token"`
-				User         castle.User        `json:"user"`
+				Params       castle.UserParams  `json:"params"`
 				Context      *castle.Context    `json:"context"`
 				Properties   map[string]string  `json:"properties"`
 			}
@@ -164,13 +166,13 @@ func TestCastle_Filter(t *testing.T) {
 			assert.True(t, ok)
 
 			err = json.NewDecoder(r.Body).Decode(reqData)
+			spew.Dump(reqData)
 			require.NoError(t, err)
 
 			assert.Equal(t, castle.EventTypeLogin, reqData.Type)
 			assert.Equal(t, castle.EventStatusSucceeded, reqData.Status)
-			assert.Equal(t, "user-id", reqData.User.ID)
+			assert.Equal(t, "user@test.com", reqData.Params.Email)
 			assert.Equal(t, map[string]string{"prop1": "propValue1"}, reqData.Properties)
-			assert.Equal(t, map[string]string{"trait1": "traitValue1"}, reqData.User.Traits)
 			assert.Equal(t, castle.FromHTTPRequest(httpReq), reqData.Context)
 
 			executed = true

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +37,7 @@ func configureRequest(httpReq *http.Request) *castle.Request {
 			Traits: map[string]string{"trait1": "traitValue1"},
 		},
 		Properties: map[string]string{"prop1": "propValue1"},
+		CreatedAt:  time.Now(),
 	}
 }
 
@@ -151,7 +153,7 @@ func TestCastle_Filter(t *testing.T) {
 				Type         castle.EventType   `json:"type"`
 				Status       castle.EventStatus `json:"status"`
 				RequestToken string             `json:"request_token"`
-				Params       castle.UserParams  `json:"params"`
+				Params       castle.Params      `json:"params"`
 				Context      *castle.Context    `json:"context"`
 				Properties   map[string]string  `json:"properties"`
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/model.go
+++ b/model.go
@@ -1,5 +1,7 @@
 package castle
 
+import "time"
+
 type Event struct {
 	EventType   EventType
 	EventStatus EventStatus
@@ -68,7 +70,32 @@ type User struct {
 	Traits       map[string]string `json:"traits,omitempty"`
 }
 
-type castleAPIRequest struct {
+type UserParams struct {
+	Email    string `json:"email,omitempty"`
+	Phone    string `json:"phone,omitempty"`
+	Username string `json:"username,omitempty"`
+}
+
+type castleAPIRequest interface {
+	GetEventType() EventType
+}
+
+type castleFilterAPIRequest struct {
+	Type         EventType         `json:"type"`
+	Name         string            `json:"name,omitempty"`
+	Status       EventStatus       `json:"status"`
+	RequestToken string            `json:"request_token"`
+	Params       UserParams        `json:"params"`
+	Context      *Context          `json:"context"`
+	Properties   map[string]string `json:"properties,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+}
+
+func (r *castleFilterAPIRequest) GetEventType() EventType {
+	return r.Type
+}
+
+type castleRiskAPIRequest struct {
 	Type         EventType         `json:"type"`
 	Name         string            `json:"name,omitempty"`
 	Status       EventStatus       `json:"status"`
@@ -76,6 +103,11 @@ type castleAPIRequest struct {
 	User         User              `json:"user"`
 	Context      *Context          `json:"context"`
 	Properties   map[string]string `json:"properties,omitempty"`
+	CreatedAt    time.Time         `json:"created_at"`
+}
+
+func (r *castleRiskAPIRequest) GetEventType() EventType {
+	return r.Type
 }
 
 type castleAPIResponse struct {

--- a/model.go
+++ b/model.go
@@ -52,6 +52,7 @@ type Request struct {
 	Event      Event
 	User       User
 	Properties map[string]string
+	CreatedAt  time.Time
 }
 
 // Context captures data from HTTP request.
@@ -70,7 +71,7 @@ type User struct {
 	Traits       map[string]string `json:"traits,omitempty"`
 }
 
-type UserParams struct {
+type Params struct {
 	Email    string `json:"email,omitempty"`
 	Phone    string `json:"phone,omitempty"`
 	Username string `json:"username,omitempty"`
@@ -85,7 +86,7 @@ type castleFilterAPIRequest struct {
 	Name         string            `json:"name,omitempty"`
 	Status       EventStatus       `json:"status"`
 	RequestToken string            `json:"request_token"`
-	Params       UserParams        `json:"params"`
+	Params       Params            `json:"params"`
 	Context      *Context          `json:"context"`
 	Properties   map[string]string `json:"properties,omitempty"`
 	CreatedAt    time.Time         `json:"created_at"`


### PR DESCRIPTION
Updating the request sent to castle to include the created_at timestamp, context [here](https://utilitywarehouse.slack.com/archives/C04UATB9796/p1722430942888279), and fix general api drift.