### PR TITLE
set user agent for request based on castle context

### DIFF
--- a/client.go
+++ b/client.go
@@ -151,6 +151,7 @@ func (c *Castle) sendCall(ctx context.Context, r castleAPIRequest, url string) (
 
 	req.SetBasicAuth("", c.apiSecret)
 	req.Header.Set("content-type", "application/json")
+	req.Header.Set("user-agent", r.GetUserAgent())
 
 	res, err := c.client.Do(req)
 	if err != nil {

--- a/context_test.go
+++ b/context_test.go
@@ -56,8 +56,6 @@ func TestToCtxFromRequest(t *testing.T) {
 		},
 	}
 	for name, test := range tests {
-		test := test
-
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -17,7 +17,12 @@ func Test_Middleware(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 
-		req, err := http.NewRequestWithContext(t.Context(), "GET", "https://example.com", nil)
+		ctx := ToCtx(t.Context(), &Context{
+			IP:           "foobar",
+			Headers:      map[string]string{},
+			RequestToken: "baz",
+		})
+		req, err := http.NewRequestWithContext(ctx, "GET", "https://example.com", nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/model.go
+++ b/model.go
@@ -1,6 +1,9 @@
 package castle
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Event struct {
 	EventType   EventType
@@ -79,6 +82,7 @@ type Params struct {
 
 type castleAPIRequest interface {
 	GetEventType() EventType
+	GetUserAgent() string
 }
 
 type castleFilterAPIRequest struct {
@@ -96,6 +100,10 @@ func (r *castleFilterAPIRequest) GetEventType() EventType {
 	return r.Type
 }
 
+func (r *castleFilterAPIRequest) GetUserAgent() string {
+	return userAgentFromContext(r.Context)
+}
+
 type castleRiskAPIRequest struct {
 	Type         EventType         `json:"type"`
 	Name         string            `json:"name,omitempty"`
@@ -111,6 +119,10 @@ func (r *castleRiskAPIRequest) GetEventType() EventType {
 	return r.Type
 }
 
+func (r *castleRiskAPIRequest) GetUserAgent() string {
+	return userAgentFromContext(r.Context)
+}
+
 type castleAPIResponse struct {
 	Type    string  `json:"type"`
 	Message string  `json:"message"`
@@ -124,4 +136,13 @@ type castleAPIResponse struct {
 	Device struct {
 		Token string `json:"token"`
 	} `json:"device"`
+}
+
+func userAgentFromContext(context *Context) string {
+	for k, v := range context.Headers {
+		if strings.ToLower(k) == "user-agent" {
+			return v
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
off the back of an incident where Castle deployed a change from evaluating rules based on the user agent passed as a request parameter to evaluating based on the user agent in the user agent header itself.

this change makes sure that the user agent in the request is the same as the original one in the castle context (i.e. not a backend service that sends requests to Castle async)